### PR TITLE
Remove 256-color limitation

### DIFF
--- a/src/palette.rs
+++ b/src/palette.rs
@@ -58,8 +58,7 @@ pub fn read_from<R: BufRead + Seek>(file: &mut R) -> Result<Palette> {
     let mut line_index = 0;
     for line_result in file.lines() {
         let line = try!(line_result);
-        if line_index == 0 && line != "JASC-PAL" || line_index == 1 && line != "0100" ||
-           line_index == 2 && line != "256" {
+        if line_index == 0 && line != "JASC-PAL" || line_index == 1 && line != "0100" {
             return Err(ErrorKind::InvalidPalette("bad header").into());
         }
         if line_index > 2 {


### PR DESCRIPTION
The JASC-PAL format specifies its third line as the number of colors in the palette - https://liero.nl/lierohack/docformats/other-jasc.html

Since this code doesn't seem to utilize the specification that targeted palettes have 256 colors, it makes sense to remove this requirement. I'm personally trying to use this for 16-color palettes.